### PR TITLE
Use org.hibernate.Session instead of EntityManager, add example with repositories that use different persistence units

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -32,3 +32,11 @@ jobs:
           popd
           pushd tests/wildfly-arquillian-tests
           mvn --batch-mode test
+          popd
+          pushd examples/multi-em-ear
+          mvn --batch-mode package
+          # test that deployment works
+          cp ear-assembly/target/multi-em-ear-assembly-1.0.0-SNAPSHOT.ear ../../tests/wildfly-arquillian-tests/target/wildfly/standalone/deployments/
+          popd
+          pushd tests/wildfly-arquillian-tests
+          mvn --batch-mode test

--- a/examples/multi-em-ear/README.md
+++ b/examples/multi-em-ear/README.md
@@ -1,0 +1,22 @@
+# Multi-Module EAR Example
+
+This example shows how two EJB modules in the same EAR can use different data
+sources by providing a separately qualified `Session` producer to avoid
+ambiguous injections.
+
+## Usage
+
+From the project root directory (where `hiberspike-data/pom.xml` is located), run:
+
+```sh
+mvn install
+```
+
+Then run in this directory:
+
+```sh
+mvn clean verify
+```
+
+Deploy `target/multi-em-ear-assembly-1.0.0-SNAPSHOT.ear` to a Jakarta EE 10
+application server. If there are no errors, multiple data sources will work.

--- a/examples/multi-em-ear/common/pom.xml
+++ b/examples/multi-em-ear/common/pom.xml
@@ -1,0 +1,19 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>ee.hiberspike.examples</groupId>
+        <artifactId>multi-em-ear</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>common</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.hibernate.orm</groupId>
+            <artifactId>hibernate-core</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/examples/multi-em-ear/common/src/main/java/org/example/common/Identifiable.java
+++ b/examples/multi-em-ear/common/src/main/java/org/example/common/Identifiable.java
@@ -1,0 +1,5 @@
+package org.example.common;
+
+public interface Identifiable<ID> {
+    ID getId();
+}

--- a/examples/multi-em-ear/ear-assembly/pom.xml
+++ b/examples/multi-em-ear/ear-assembly/pom.xml
@@ -1,0 +1,46 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>ee.hiberspike.examples</groupId>
+        <artifactId>multi-em-ear</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>multi-em-ear-assembly</artifactId>
+    <packaging>ear</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>module-a-ejb</artifactId>
+            <version>${project.version}</version>
+            <type>ejb</type>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>module-b-ejb</artifactId>
+            <version>${project.version}</version>
+            <type>ejb</type>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>2.2.224</version>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-ear-plugin</artifactId>
+                <version>3.3.0</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/multi-em-ear/module-a-ejb/pom.xml
+++ b/examples/multi-em-ear/module-a-ejb/pom.xml
@@ -1,0 +1,53 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>ee.hiberspike.examples</groupId>
+        <artifactId>multi-em-ear</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>module-a-ejb</artifactId>
+    <packaging>ejb</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>ee.hiberspike</groupId>
+            <artifactId>hiberspike-data</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.orm</groupId>
+            <artifactId>hibernate-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+              <artifactId>maven-ejb-plugin</artifactId>
+              <version>3.2.1</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.14.0</version>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.hibernate.orm</groupId>
+                            <artifactId>hibernate-jpamodelgen</artifactId>
+                            <version>${hibernate.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/multi-em-ear/module-a-ejb/src/main/java/org/example/modulea/EmProducerA.java
+++ b/examples/multi-em-ear/module-a-ejb/src/main/java/org/example/modulea/EmProducerA.java
@@ -1,0 +1,29 @@
+package org.example.modulea;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.PersistenceContextType;
+import jakarta.annotation.sql.DataSourceDefinition;
+import org.hibernate.Session;
+
+@DataSourceDefinition(
+        name = "java:/jdbc/DSA",
+        className = "org.h2.jdbcx.JdbcDataSource",
+        url = "jdbc:h2:mem:dsa;DB_CLOSE_DELAY=-1",
+        user = "sa",
+        password = "sa"
+)
+@ApplicationScoped
+public class EmProducerA {
+
+    @PersistenceContext(unitName = "pu-a", type = PersistenceContextType.EXTENDED)
+    EntityManager em;
+
+    @Produces
+    @FooAQualifier
+    Session fooASession() {
+        return em.unwrap(Session.class);
+    }
+}

--- a/examples/multi-em-ear/module-a-ejb/src/main/java/org/example/modulea/FooA.java
+++ b/examples/multi-em-ear/module-a-ejb/src/main/java/org/example/modulea/FooA.java
@@ -1,0 +1,29 @@
+package org.example.modulea;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "FOO_A")
+public class FooA {
+    @Id
+    private Long id;
+    private String name;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/examples/multi-em-ear/module-a-ejb/src/main/java/org/example/modulea/FooAQualifier.java
+++ b/examples/multi-em-ear/module-a-ejb/src/main/java/org/example/modulea/FooAQualifier.java
@@ -1,0 +1,14 @@
+package org.example.modulea;
+
+import jakarta.inject.Qualifier;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE_USE, ElementType.METHOD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Qualifier
+public @interface FooAQualifier {
+}

--- a/examples/multi-em-ear/module-a-ejb/src/main/java/org/example/modulea/FooARepository.java
+++ b/examples/multi-em-ear/module-a-ejb/src/main/java/org/example/modulea/FooARepository.java
@@ -1,0 +1,21 @@
+package org.example.modulea;
+
+import ee.hiberspike.data.ExtendedEntityRepository;
+import org.hibernate.Session;
+import org.hibernate.annotations.processing.Find;
+
+public interface FooARepository extends ExtendedEntityRepository<FooA, Long> {
+
+    @Find
+    FooA findById_UNUSED(Long id);
+
+    @Override
+    @FooAQualifier
+    Session session();
+
+    @Override
+    default Class<FooA> getEntityClass() {
+        return FooA.class;
+    }
+
+}

--- a/examples/multi-em-ear/module-a-ejb/src/main/java/org/example/modulea/FooAService.java
+++ b/examples/multi-em-ear/module-a-ejb/src/main/java/org/example/modulea/FooAService.java
@@ -1,0 +1,15 @@
+package org.example.modulea;
+
+import jakarta.ejb.Stateless;
+import jakarta.inject.Inject;
+
+@Stateless
+public class FooAService {
+    @Inject
+    FooARepository repo;
+
+    public long saveAndCount(FooA foo) {
+        repo.saveAndFlush(foo);
+        return repo.count();
+    }
+}

--- a/examples/multi-em-ear/module-a-ejb/src/main/resources/META-INF/beans.xml
+++ b/examples/multi-em-ear/module-a-ejb/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,1 @@
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" version="4.0"/>

--- a/examples/multi-em-ear/module-a-ejb/src/main/resources/META-INF/persistence.xml
+++ b/examples/multi-em-ear/module-a-ejb/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence" version="3.0">
+    <persistence-unit name="pu-a">
+        <jta-data-source>jdbc/DSA</jta-data-source>
+        <properties>
+            <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/examples/multi-em-ear/module-b-ejb/pom.xml
+++ b/examples/multi-em-ear/module-b-ejb/pom.xml
@@ -1,0 +1,53 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>ee.hiberspike.examples</groupId>
+        <artifactId>multi-em-ear</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>module-b-ejb</artifactId>
+    <packaging>ejb</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>ee.hiberspike</groupId>
+            <artifactId>hiberspike-data</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.orm</groupId>
+            <artifactId>hibernate-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+              <artifactId>maven-ejb-plugin</artifactId>
+              <version>3.2.1</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.14.0</version>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.hibernate.orm</groupId>
+                            <artifactId>hibernate-jpamodelgen</artifactId>
+                            <version>${hibernate.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/multi-em-ear/module-b-ejb/src/main/java/org/example/moduleb/EmProducerB.java
+++ b/examples/multi-em-ear/module-b-ejb/src/main/java/org/example/moduleb/EmProducerB.java
@@ -1,0 +1,29 @@
+package org.example.moduleb;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.PersistenceContextType;
+import jakarta.annotation.sql.DataSourceDefinition;
+import org.hibernate.Session;
+
+@DataSourceDefinition(
+        name = "java:/jdbc/DSB",
+        className = "org.h2.jdbcx.JdbcDataSource",
+        url = "jdbc:h2:mem:dsb;DB_CLOSE_DELAY=-1",
+        user = "sa",
+        password = "sa"
+)
+@ApplicationScoped
+public class EmProducerB {
+
+    @PersistenceContext(unitName = "pu-b", type = PersistenceContextType.EXTENDED)
+    EntityManager em;
+
+    @Produces
+    @FooBQualifier
+    Session fooBSession() {
+        return em.unwrap(Session.class);
+    }
+}

--- a/examples/multi-em-ear/module-b-ejb/src/main/java/org/example/moduleb/FooB.java
+++ b/examples/multi-em-ear/module-b-ejb/src/main/java/org/example/moduleb/FooB.java
@@ -1,0 +1,29 @@
+package org.example.moduleb;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "FOO_B")
+public class FooB {
+    @Id
+    private Long id;
+    private String text;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+}

--- a/examples/multi-em-ear/module-b-ejb/src/main/java/org/example/moduleb/FooBQualifier.java
+++ b/examples/multi-em-ear/module-b-ejb/src/main/java/org/example/moduleb/FooBQualifier.java
@@ -1,0 +1,14 @@
+package org.example.moduleb;
+
+import jakarta.inject.Qualifier;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE_USE, ElementType.METHOD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Qualifier
+public @interface FooBQualifier {
+}

--- a/examples/multi-em-ear/module-b-ejb/src/main/java/org/example/moduleb/FooBRepository.java
+++ b/examples/multi-em-ear/module-b-ejb/src/main/java/org/example/moduleb/FooBRepository.java
@@ -1,0 +1,16 @@
+package org.example.moduleb;
+
+import ee.hiberspike.data.EntityRepository;
+import org.hibernate.Session;
+import org.hibernate.annotations.processing.Find;
+
+public interface FooBRepository extends EntityRepository<FooB, Long> {
+
+    @Find
+    FooB findById_UNUSED(Long id);
+
+    @Override
+    @FooBQualifier
+    Session session();
+
+}

--- a/examples/multi-em-ear/module-b-ejb/src/main/java/org/example/moduleb/FooBService.java
+++ b/examples/multi-em-ear/module-b-ejb/src/main/java/org/example/moduleb/FooBService.java
@@ -1,0 +1,17 @@
+package org.example.moduleb;
+
+import jakarta.ejb.Stateless;
+import jakarta.inject.Inject;
+
+import java.util.List;
+
+@Stateless
+public class FooBService {
+    @Inject
+    FooBRepository repo;
+
+    public List<FooB> saveAndFindAll(FooB foo) {
+        repo.saveAndFlush(foo);
+        return repo.findAll();
+    }
+}

--- a/examples/multi-em-ear/module-b-ejb/src/main/resources/META-INF/beans.xml
+++ b/examples/multi-em-ear/module-b-ejb/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,1 @@
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" version="4.0"/>

--- a/examples/multi-em-ear/module-b-ejb/src/main/resources/META-INF/persistence.xml
+++ b/examples/multi-em-ear/module-b-ejb/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence" version="3.0">
+    <persistence-unit name="pu-b">
+        <jta-data-source>jdbc/DSB</jta-data-source>
+        <properties>
+            <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/examples/multi-em-ear/pom.xml
+++ b/examples/multi-em-ear/pom.xml
@@ -1,0 +1,44 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>ee.hiberspike.examples</groupId>
+    <artifactId>multi-em-ear</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>common</module>
+        <module>module-a-ejb</module>
+        <module>module-b-ejb</module>
+        <module>ear-assembly</module>
+    </modules>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <hibernate.version>6.6.13.Final</hibernate.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>jakarta.platform</groupId>
+                <artifactId>jakarta.jakartaee-api</artifactId>
+                <version>10.0.0</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.orm</groupId>
+                <artifactId>hibernate-core</artifactId>
+                <version>${hibernate.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>ee.hiberspike</groupId>
+                <artifactId>hiberspike-data</artifactId>
+                <version>1.0.0-SNAPSHOT</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/src/main/java/ee/hiberspike/data/ExtendedEntityRepository.java
+++ b/src/main/java/ee/hiberspike/data/ExtendedEntityRepository.java
@@ -32,7 +32,7 @@ public interface ExtendedEntityRepository<E, PK extends Serializable>
      * @return Entity identified by primary key or null if it does not exist.
      */
     default E findBy(PK id) {
-        return entityManager().find(getEntityClass(), id);
+        return session().find(getEntityClass(), id);
     }
 
     /**
@@ -51,10 +51,10 @@ public interface ExtendedEntityRepository<E, PK extends Serializable>
      * @return Counter.
      */
     default Long count() {
-        CriteriaBuilder cb = entityManager().getCriteriaBuilder();
+        CriteriaBuilder cb = session().getCriteriaBuilder();
         CriteriaQuery<Long> cq = cb.createQuery(Long.class);
         cq.select(cb.count(cq.from(getEntityClass())));
-        return entityManager().createQuery(cq).getSingleResult();
+        return session().createQuery(cq).getSingleResult();
     }
 
     /**


### PR DESCRIPTION
Note that only `org.hibernate.Session` works with qualifier annotations. Using qualifiers with `EntityManager` breaks _jpamodelgen_ code generation in Hibernate 6.6. Qualifier annotations can be used with producer methods to inject different persistence units into repositories.